### PR TITLE
Add automated release workflow and manual build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release Binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-mac:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build Mac binary
+        run: |
+          cd server
+          swift build -c release
+
+      - name: Create .app bundle
+        run: |
+          APP_NAME="Daylight Mirror"
+          APP_BUNDLE="build/$APP_NAME.app"
+          BINARY="server/.build/release/DaylightMirror"
+
+          mkdir -p "$APP_BUNDLE/Contents/MacOS"
+          mkdir -p "$APP_BUNDLE/Contents/Resources"
+          cp "$BINARY" "$APP_BUNDLE/Contents/MacOS/DaylightMirror"
+
+          # Update Info.plist with version from tag
+          sed "s/<string>1.0<\/string>/<string>${{ steps.version.outputs.VERSION }}<\/string>/g" Info.plist > "$APP_BUNDLE/Contents/Info.plist"
+
+          cp Resources/AppIcon.icns "$APP_BUNDLE/Contents/Resources/AppIcon.icns"
+
+          # Ad-hoc codesign (for local distribution)
+          codesign --force --deep -s - "$APP_BUNDLE"
+
+      - name: Create DMG
+        run: |
+          brew install create-dmg
+          create-dmg \
+            --volname "Daylight Mirror ${{ steps.version.outputs.VERSION }}" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "Daylight Mirror.app" 175 120 \
+            --hide-extension "Daylight Mirror.app" \
+            --app-drop-link 425 120 \
+            "DaylightMirror-v${{ steps.version.outputs.VERSION }}.dmg" \
+            "build/Daylight Mirror.app" || true
+
+          # Fallback to hdiutil if create-dmg fails
+          if [ ! -f "DaylightMirror-v${{ steps.version.outputs.VERSION }}.dmg" ]; then
+            echo "create-dmg failed, using hdiutil fallback"
+            hdiutil create -volname "Daylight Mirror ${{ steps.version.outputs.VERSION }}" \
+              -srcfolder "build/Daylight Mirror.app" \
+              -ov -format UDZO \
+              "DaylightMirror-v${{ steps.version.outputs.VERSION }}.dmg"
+          fi
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-dmg
+          path: DaylightMirror-v${{ steps.version.outputs.VERSION }}.dmg
+
+  build-android:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Update version in build.gradle.kts
+        run: |
+          cd android/app
+          # Update versionName to match tag
+          sed -i "s/versionName = \"1.0\"/versionName = \"${{ steps.version.outputs.VERSION }}\"/" build.gradle.kts
+
+      - name: Build APK
+        run: |
+          cd android
+          chmod +x gradlew
+          ./gradlew assembleDebug
+
+      - name: Rename APK
+        run: |
+          cp android/app/build/outputs/apk/debug/app-debug.apk \
+             DaylightMirror-v${{ steps.version.outputs.VERSION }}.apk
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: DaylightMirror-v${{ steps.version.outputs.VERSION }}.apk
+
+  create-release:
+    needs: [build-mac, build-android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Download Mac artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mac-dmg
+
+      - name: Download Android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            DaylightMirror-v${{ steps.version.outputs.VERSION }}.dmg
+            DaylightMirror-v${{ steps.version.outputs.VERSION }}.apk
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Manual release build script for retroactive v1.1 and v1.2 releases
+#
+# Usage: ./scripts/build-release.sh v1.1
+#        ./scripts/build-release.sh v1.2
+#
+# Prerequisites:
+#   - brew install create-dmg
+#   - Android SDK installed (for APK build)
+#   - gh CLI installed (for uploading to GitHub)
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <tag>"
+  echo "Example: $0 v1.1"
+  exit 1
+fi
+
+TAG="$1"
+VERSION="${TAG#v}"
+
+echo "Building release for $TAG (version $VERSION)..."
+
+# Save current branch
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Checkout tag
+echo "Checking out $TAG..."
+git checkout "$TAG"
+
+# Build Mac binary
+echo "Building Mac binary..."
+cd server
+swift build -c release
+cd ..
+
+# Create .app bundle
+echo "Creating .app bundle..."
+APP_BUNDLE="build/Daylight Mirror.app"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+cp server/.build/release/DaylightMirror "$APP_BUNDLE/Contents/MacOS/DaylightMirror"
+
+# Update Info.plist with correct version
+sed "s/<string>1.0<\/string>/<string>$VERSION<\/string>/g" Info.plist > "$APP_BUNDLE/Contents/Info.plist"
+
+cp Resources/AppIcon.icns "$APP_BUNDLE/Contents/Resources/AppIcon.icns"
+
+# Codesign
+echo "Codesigning..."
+codesign --force --deep -s - "$APP_BUNDLE"
+
+# Create DMG
+echo "Creating DMG..."
+if command -v create-dmg &> /dev/null; then
+  create-dmg \
+    --volname "Daylight Mirror $VERSION" \
+    --window-pos 200 120 \
+    --window-size 600 400 \
+    --icon-size 100 \
+    --icon "Daylight Mirror.app" 175 120 \
+    --hide-extension "Daylight Mirror.app" \
+    --app-drop-link 425 120 \
+    "DaylightMirror-$TAG.dmg" \
+    "$APP_BUNDLE" || {
+      echo "create-dmg failed, falling back to hdiutil..."
+      hdiutil create -volname "Daylight Mirror $VERSION" \
+        -srcfolder "$APP_BUNDLE" \
+        -ov -format UDZO \
+        "DaylightMirror-$TAG.dmg"
+    }
+else
+  echo "create-dmg not found, using hdiutil..."
+  hdiutil create -volname "Daylight Mirror $VERSION" \
+    -srcfolder "$APP_BUNDLE" \
+    -ov -format UDZO \
+    "DaylightMirror-$TAG.dmg"
+fi
+
+# Build Android APK
+echo "Building Android APK..."
+cd android
+
+# Update version in build.gradle.kts
+sed -i.bak "s/versionName = \"1.0\"/versionName = \"$VERSION\"/" app/build.gradle.kts
+
+./gradlew assembleDebug
+
+# Restore original build.gradle.kts
+mv app/build.gradle.kts.bak app/build.gradle.kts
+
+cd ..
+
+# Copy and rename APK
+cp android/app/build/outputs/apk/debug/app-debug.apk "DaylightMirror-$TAG.apk"
+
+echo ""
+echo "Build complete!"
+echo "  DMG: DaylightMirror-$TAG.dmg"
+echo "  APK: DaylightMirror-$TAG.apk"
+echo ""
+
+# Upload to GitHub release
+read -p "Upload to GitHub release $TAG? (y/N) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  echo "Uploading to GitHub..."
+  gh release upload "$TAG" "DaylightMirror-$TAG.dmg" "DaylightMirror-$TAG.apk"
+  echo "Upload complete!"
+else
+  echo "Skipping upload. To upload manually, run:"
+  echo "  gh release upload $TAG DaylightMirror-$TAG.dmg DaylightMirror-$TAG.apk"
+fi
+
+# Return to original branch
+echo "Returning to $CURRENT_BRANCH..."
+git checkout "$CURRENT_BRANCH"
+
+echo "Done!"


### PR DESCRIPTION
## Summary

**What**: Adds a GitHub Actions workflow (`.github/workflows/release.yml`) triggered on `v*` tag pushes, plus a manual build script (`scripts/build-release.sh`) for retroactive releases.

**Why**: There is currently no automated way to build and publish release binaries. Users must clone the repo and build from source, which is a barrier to adoption. This automates the entire build-package-publish pipeline.

**How it works**: The workflow runs three parallel jobs:
- **build-mac** (macOS runner): Compiles the Swift server in release mode, assembles a `.app` bundle with versioned `Info.plist`, ad-hoc codesigns it, and packages it into a DMG (using `create-dmg` with `hdiutil` fallback).
- **build-android** (Ubuntu runner): Sets up JDK 17 and Android SDK, patches `versionName` in `build.gradle.kts` from the tag, builds a debug APK via Gradle.
- **create-release**: Waits for both build jobs, downloads artifacts, and creates a GitHub Release with auto-generated release notes and both binaries attached.

The version is extracted from the git tag (e.g., `v1.3` yields version `1.3`) and injected into both platform builds.

The manual script (`scripts/build-release.sh`) handles retroactive builds for v1.1 and v1.2, which were tagged before CI existed. It checks out the tag locally, builds both platforms, and optionally uploads artifacts via `gh release upload`.

## Files Changed

| File | Purpose |
|------|---------|
| `.github/workflows/release.yml` | GitHub Actions workflow: three parallel jobs (build-mac, build-android, create-release) triggered on v* tag push |
| `scripts/build-release.sh` | Manual build script for retroactive releases of pre-CI tags (v1.1, v1.2) |

## How to Test

1. **Dry run the workflow** (no actual release): Push a test tag like `v0.0.1-test`, observe the Actions run, then delete the tag and release.
2. **Test the manual script locally**: `./scripts/build-release.sh v1.3` (requires Swift toolchain, Android SDK, `create-dmg`).
3. **Full release**: After merging, tag with `git tag v1.4 && git push origin v1.4` and the workflow will build and publish automatically.

## Known Limitations

- **Mac codesigning is ad-hoc** (`-s -`): The DMG will trigger Gatekeeper warnings. Users need to right-click > Open on first launch. Full signing requires an Apple Developer certificate in GitHub Secrets.
- **Android APK is a debug build**: `assembleDebug` is used because release builds require a signing keystore. A future improvement would add a release keystore to GitHub Secrets and use `assembleRelease`.
- **No caching**: Gradle and Swift dependencies are downloaded fresh each run. Adding caching would speed up builds.

---

Generated with [Claude Code](https://claude.com/claude-code)