### PR TITLE
Add CI workflow, expand test coverage (23 → 104), and add CONTRIBUTING.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to Daylight Mirror
+
+Contributions are welcome. This guide helps you understand the codebase and submit quality PRs.
+
+## Getting Started
+
+### Prerequisites
+
+- macOS 14 or later
+- Xcode or Swift 5.9+
+- `adb` (optional): `brew install android-platform-tools`
+
+### Clone and Build
+
+```bash
+git clone https://github.com/welfvh/daylight-mirror
+cd daylight-mirror
+swift build
+swift test
+```
+
+### Run
+
+```bash
+swift run DaylightMirror    # Menu bar app
+swift run daylight-mirror   # CLI
+```
+
+### Optional: Build Bundles
+
+```bash
+make install    # Mac .app → ~/Applications
+make deploy     # Android APK → Daylight (requires Android SDK)
+```
+
+## Architecture Overview
+
+```
+Sources/
+  MirrorEngine/          # Core library (shared by GUI + CLI)
+    MirrorEngine.swift   # Orchestrator — wires everything together
+    Configuration.swift  # Constants, resolution presets, protocol defs
+    ADBBridge.swift      # ADB binary discovery + device commands
+    ScreenCapture.swift  # SCStream → vImage greyscale → LZ4 delta
+    TCPServer.swift      # Native TCP frame server (raw protocol)
+    WebSocketServer.swift # WS fallback for browser viewers
+    HTTPServer.swift     # Serves HTML viewer page
+    ControlSocket.swift  # Unix socket IPC for CLI commands
+    DisplayController.swift # Keyboard shortcuts for brightness/warmth
+    CompositorPacer.swift   # Dirty-pixel trick for 30fps capture
+    VirtualDisplayManager.swift # CGVirtualDisplay private API
+    USBDeviceMonitor.swift # Auto-detect DC-1 connect/disconnect
+    MacBrightness.swift    # IOKit Mac brightness control
+    UpdateChecker.swift    # GitHub release version check
+  App/                   # SwiftUI menu bar app
+  Mirror/                # CLI entry point
+  CLZ4/                  # C LZ4 compression library
+  CVirtualDisplay/       # C bridge for CGVirtualDisplay private API
+Tests/
+  MirrorEngineTests/     # Unit tests (swift test)
+android/                 # Android companion app (Kotlin + native C)
+```
+
+## How It Works
+
+Mac creates a virtual display at the DC-1's resolution, mirrors the built-in display to it, captures frames via ScreenCaptureKit, converts to greyscale with vImage SIMD, compresses with LZ4 (keyframes + XOR deltas), and streams over TCP to the Android app which renders via a native C SurfaceView. Zero GPU usage. Under 10ms latency.
+
+## Development Workflow
+
+1. Fork the repo and create a feature branch
+2. Make changes, run `swift build && swift test`
+3. CI runs automatically on PRs (build + test on macOS)
+4. Keep PRs focused — one feature or fix per PR
+5. Follow existing code style (no linter configured, but the codebase is consistent)
+
+## Testing
+
+Tests live in `Tests/MirrorEngineTests/`. Run with:
+
+```bash
+swift test
+```
+
+Tests cover pure logic only (no hardware, no network, no GUI). When adding new logic, add tests. When fixing bugs, add a regression test.
+
+## What to Contribute
+
+- Bug fixes (check issues)
+- Test coverage for untested modules
+- Documentation improvements
+- Performance optimizations (capture pipeline, compression)
+- New display presets or control features
+
+## Pull Request Guidelines
+
+- One feature or fix per PR
+- Include tests for new logic
+- Update documentation if behavior changes
+- Verify `swift build && swift test` passes before submitting
+- Write clear commit messages describing the "why" not the "what"
+
+## Questions?
+
+Open an issue or check the [blog series](blog/) for deep dives into the architecture.

--- a/Tests/MirrorEngineTests/DisplayControllerTests.swift
+++ b/Tests/MirrorEngineTests/DisplayControllerTests.swift
@@ -1,0 +1,209 @@
+import XCTest
+@testable import MirrorEngine
+
+final class DisplayControllerTests: XCTestCase {
+
+    private var tcpServer: TCPServer!
+    private var controller: DisplayController!
+
+    override func setUp() {
+        super.setUp()
+        // Create a TCPServer on a high port — never started, so no actual listening.
+        // sendCommand just iterates an empty connections array, which is safe.
+        tcpServer = try! TCPServer(port: 19888)
+        controller = DisplayController(tcpServer: tcpServer)
+    }
+
+    override func tearDown() {
+        controller = nil
+        tcpServer = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial state
+
+    func testInitialBrightness() {
+        XCTAssertEqual(controller.currentBrightness, 128)
+    }
+
+    func testInitialWarmth() {
+        XCTAssertEqual(controller.currentWarmth, 128)
+    }
+
+    func testInitialBacklightOn() {
+        XCTAssertTrue(controller.backlightOn)
+    }
+
+    func testInitialSavedBrightness() {
+        XCTAssertEqual(controller.savedBrightness, 128)
+    }
+
+    // MARK: - setBrightness clamping
+
+    func testSetBrightnessNormal() {
+        controller.setBrightness(200)
+        XCTAssertEqual(controller.currentBrightness, 200)
+    }
+
+    func testSetBrightnessClampsAbove255() {
+        controller.setBrightness(300)
+        XCTAssertEqual(controller.currentBrightness, 255)
+    }
+
+    func testSetBrightnessClampsBelowZero() {
+        controller.setBrightness(-5)
+        XCTAssertEqual(controller.currentBrightness, 0)
+    }
+
+    func testSetBrightnessAtZero() {
+        controller.setBrightness(0)
+        XCTAssertEqual(controller.currentBrightness, 0)
+    }
+
+    func testSetBrightnessAt255() {
+        controller.setBrightness(255)
+        XCTAssertEqual(controller.currentBrightness, 255)
+    }
+
+    func testSetBrightnessUpdatesBacklightOn() {
+        controller.setBrightness(100)
+        XCTAssertTrue(controller.backlightOn)
+
+        controller.setBrightness(0)
+        XCTAssertFalse(controller.backlightOn)
+    }
+
+    func testSetBrightnessSavesBrightness() {
+        controller.setBrightness(200)
+        // savedBrightness = max(currentBrightness, 1)
+        XCTAssertEqual(controller.savedBrightness, 200)
+    }
+
+    func testSetBrightnessZeroSavedIsAtLeastOne() {
+        controller.setBrightness(0)
+        // savedBrightness = max(0, 1) = 1
+        XCTAssertEqual(controller.savedBrightness, 1)
+    }
+
+    // MARK: - setWarmth clamping
+
+    func testSetWarmthNormal() {
+        controller.setWarmth(100)
+        XCTAssertEqual(controller.currentWarmth, 100)
+    }
+
+    func testSetWarmthClampsAbove255() {
+        controller.setWarmth(300)
+        XCTAssertEqual(controller.currentWarmth, 255)
+    }
+
+    func testSetWarmthClampsBelowZero() {
+        controller.setWarmth(-5)
+        XCTAssertEqual(controller.currentWarmth, 0)
+    }
+
+    func testSetWarmthAtZero() {
+        controller.setWarmth(0)
+        XCTAssertEqual(controller.currentWarmth, 0)
+    }
+
+    func testSetWarmthAt255() {
+        controller.setWarmth(255)
+        XCTAssertEqual(controller.currentWarmth, 255)
+    }
+
+    // MARK: - toggleBacklight
+
+    func testToggleBacklightOff() {
+        // Start with backlight on, brightness 128
+        controller.currentBrightness = 128
+        controller.backlightOn = true
+
+        controller.toggleBacklight()
+
+        XCTAssertFalse(controller.backlightOn)
+        XCTAssertEqual(controller.currentBrightness, 0)
+        XCTAssertEqual(controller.savedBrightness, 128, "Should save brightness before turning off")
+    }
+
+    func testToggleBacklightOnRestoresBrightness() {
+        // Set up: backlight on at 200
+        controller.currentBrightness = 200
+        controller.savedBrightness = 200
+        controller.backlightOn = true
+
+        // Toggle off
+        controller.toggleBacklight()
+        XCTAssertEqual(controller.currentBrightness, 0)
+        XCTAssertFalse(controller.backlightOn)
+
+        // Toggle back on
+        controller.toggleBacklight()
+        XCTAssertTrue(controller.backlightOn)
+        XCTAssertEqual(controller.currentBrightness, 200, "Should restore saved brightness")
+    }
+
+    func testToggleBacklightSavesAtLeastOne() {
+        // Edge case: brightness is 0 but backlight is "on"
+        controller.currentBrightness = 0
+        controller.backlightOn = true
+
+        controller.toggleBacklight()
+        // savedBrightness = max(0, 1) = 1
+        XCTAssertEqual(controller.savedBrightness, 1)
+    }
+
+    func testDoubleToggleIsRoundTrip() {
+        controller.currentBrightness = 150
+        controller.savedBrightness = 150
+        controller.backlightOn = true
+
+        controller.toggleBacklight()  // off
+        controller.toggleBacklight()  // on
+
+        XCTAssertTrue(controller.backlightOn)
+        XCTAssertEqual(controller.currentBrightness, 150)
+    }
+
+    // MARK: - Callbacks
+
+    func testBrightnessCallbackFires() {
+        var received: Int?
+        controller.onBrightnessChanged = { received = $0 }
+
+        controller.setBrightness(42)
+        XCTAssertEqual(received, 42)
+    }
+
+    func testWarmthCallbackFires() {
+        var received: Int?
+        controller.onWarmthChanged = { received = $0 }
+
+        controller.setWarmth(77)
+        XCTAssertEqual(received, 77)
+    }
+
+    func testBacklightCallbackFires() {
+        var received: Bool?
+        controller.onBacklightChanged = { received = $0 }
+
+        controller.setBrightness(0)
+        XCTAssertEqual(received, false)
+
+        controller.setBrightness(100)
+        XCTAssertEqual(received, true)
+    }
+
+    func testToggleBacklightCallbackFires() {
+        var brightnessValues: [Int] = []
+        var backlightValues: [Bool] = []
+        controller.onBrightnessChanged = { brightnessValues.append($0) }
+        controller.onBacklightChanged = { backlightValues.append($0) }
+
+        controller.toggleBacklight()  // off
+        controller.toggleBacklight()  // on
+
+        XCTAssertEqual(brightnessValues.count, 2)
+        XCTAssertEqual(backlightValues, [false, true])
+    }
+}

--- a/Tests/MirrorEngineTests/MirrorStatusTests.swift
+++ b/Tests/MirrorEngineTests/MirrorStatusTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import MirrorEngine
+
+final class MirrorStatusTests: XCTestCase {
+
+    // MARK: - Equality
+
+    func testIdleEqualsIdle() {
+        XCTAssertEqual(MirrorStatus.idle, MirrorStatus.idle)
+    }
+
+    func testWaitingForDeviceEqualsWaitingForDevice() {
+        XCTAssertEqual(MirrorStatus.waitingForDevice, MirrorStatus.waitingForDevice)
+    }
+
+    func testStartingEqualsStarting() {
+        XCTAssertEqual(MirrorStatus.starting, MirrorStatus.starting)
+    }
+
+    func testRunningEqualsRunning() {
+        XCTAssertEqual(MirrorStatus.running, MirrorStatus.running)
+    }
+
+    func testStoppingEqualsStopping() {
+        XCTAssertEqual(MirrorStatus.stopping, MirrorStatus.stopping)
+    }
+
+    func testErrorEqualsSameMessage() {
+        XCTAssertEqual(MirrorStatus.error("timeout"), MirrorStatus.error("timeout"))
+    }
+
+    func testErrorEqualsEmptyMessage() {
+        XCTAssertEqual(MirrorStatus.error(""), MirrorStatus.error(""))
+    }
+
+    // MARK: - Inequality
+
+    func testIdleNotEqualRunning() {
+        XCTAssertNotEqual(MirrorStatus.idle, MirrorStatus.running)
+    }
+
+    func testIdleNotEqualStarting() {
+        XCTAssertNotEqual(MirrorStatus.idle, MirrorStatus.starting)
+    }
+
+    func testIdleNotEqualStopping() {
+        XCTAssertNotEqual(MirrorStatus.idle, MirrorStatus.stopping)
+    }
+
+    func testIdleNotEqualWaitingForDevice() {
+        XCTAssertNotEqual(MirrorStatus.idle, MirrorStatus.waitingForDevice)
+    }
+
+    func testRunningNotEqualStopping() {
+        XCTAssertNotEqual(MirrorStatus.running, MirrorStatus.stopping)
+    }
+
+    func testStartingNotEqualRunning() {
+        XCTAssertNotEqual(MirrorStatus.starting, MirrorStatus.running)
+    }
+
+    func testErrorDifferentMessages() {
+        XCTAssertNotEqual(MirrorStatus.error("x"), MirrorStatus.error("y"))
+    }
+
+    func testErrorNotEqualIdle() {
+        XCTAssertNotEqual(MirrorStatus.error("something"), MirrorStatus.idle)
+    }
+
+    func testErrorNotEqualRunning() {
+        XCTAssertNotEqual(MirrorStatus.error("fail"), MirrorStatus.running)
+    }
+
+    // MARK: - All cases exist
+
+    func testAllCasesCanBeConstructed() {
+        // Verify every case of MirrorStatus can be created
+        let cases: [MirrorStatus] = [
+            .idle,
+            .waitingForDevice,
+            .starting,
+            .running,
+            .stopping,
+            .error("test"),
+        ]
+        XCTAssertEqual(cases.count, 6, "MirrorStatus should have 6 cases")
+    }
+
+    func testEachCaseIsDistinct() {
+        let cases: [MirrorStatus] = [
+            .idle,
+            .waitingForDevice,
+            .starting,
+            .running,
+            .stopping,
+            .error("test"),
+        ]
+        // Every pair should be unequal
+        for i in 0..<cases.count {
+            for j in (i + 1)..<cases.count {
+                XCTAssertNotEqual(cases[i], cases[j],
+                                  "\(cases[i]) should not equal \(cases[j])")
+            }
+        }
+    }
+}

--- a/Tests/MirrorEngineTests/ProtocolTests.swift
+++ b/Tests/MirrorEngineTests/ProtocolTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import MirrorEngine
+
+final class ProtocolTests: XCTestCase {
+
+    // MARK: - Magic bytes
+
+    func testMagicFrameBytes() {
+        XCTAssertEqual(MAGIC_FRAME, [0xDA, 0x7E])
+    }
+
+    func testMagicCmdBytes() {
+        XCTAssertEqual(MAGIC_CMD, [0xDA, 0x7F])
+    }
+
+    func testMagicFrameAndCmdDiffer() {
+        XCTAssertNotEqual(MAGIC_FRAME, MAGIC_CMD,
+                          "Frame and command magic must be distinguishable")
+    }
+
+    // MARK: - Flags
+
+    func testFlagKeyframe() {
+        XCTAssertEqual(FLAG_KEYFRAME, 0x01)
+    }
+
+    // MARK: - Command IDs
+
+    func testCmdBrightness() {
+        XCTAssertEqual(CMD_BRIGHTNESS, 0x01)
+    }
+
+    func testCmdWarmth() {
+        XCTAssertEqual(CMD_WARMTH, 0x02)
+    }
+
+    func testCmdBacklightToggle() {
+        XCTAssertEqual(CMD_BACKLIGHT_TOGGLE, 0x03)
+    }
+
+    func testCmdResolution() {
+        XCTAssertEqual(CMD_RESOLUTION, 0x04)
+    }
+
+    func testCommandIDsAreUnique() {
+        let ids: [UInt8] = [CMD_BRIGHTNESS, CMD_WARMTH, CMD_BACKLIGHT_TOGGLE, CMD_RESOLUTION]
+        XCTAssertEqual(ids.count, Set(ids).count, "All command IDs must be unique")
+    }
+
+    // MARK: - Frame header layout
+
+    func testFrameHeaderIs7Bytes() {
+        // Build a frame header the same way TCPServer.broadcast does:
+        // [magic:2][flags:1][len:4 LE]
+        var header = Data(capacity: 7)
+        header.append(contentsOf: MAGIC_FRAME)
+        header.append(FLAG_KEYFRAME)
+        var len = UInt32(1024).littleEndian
+        header.append(Data(bytes: &len, count: 4))
+
+        XCTAssertEqual(header.count, 7)
+    }
+
+    func testFrameHeaderMagicPrefix() {
+        var header = Data()
+        header.append(contentsOf: MAGIC_FRAME)
+        header.append(0x00) // flags
+        var len = UInt32(0).littleEndian
+        header.append(Data(bytes: &len, count: 4))
+
+        XCTAssertEqual(header[0], 0xDA)
+        XCTAssertEqual(header[1], 0x7E)
+    }
+
+    func testFrameHeaderFlagsPosition() {
+        var header = Data()
+        header.append(contentsOf: MAGIC_FRAME)
+        header.append(FLAG_KEYFRAME)
+        var len = UInt32(0).littleEndian
+        header.append(Data(bytes: &len, count: 4))
+
+        XCTAssertEqual(header[2], FLAG_KEYFRAME, "Flags byte is at offset 2")
+    }
+
+    func testFrameHeaderLengthIsLittleEndian() {
+        var header = Data()
+        header.append(contentsOf: MAGIC_FRAME)
+        header.append(0x00)
+        let payloadSize: UInt32 = 0x01020304
+        var len = payloadSize.littleEndian
+        header.append(Data(bytes: &len, count: 4))
+
+        // Little-endian: least significant byte first
+        XCTAssertEqual(header[3], 0x04)
+        XCTAssertEqual(header[4], 0x03)
+        XCTAssertEqual(header[5], 0x02)
+        XCTAssertEqual(header[6], 0x01)
+    }
+
+    func testNonKeyframeHasFlagZero() {
+        var header = Data()
+        header.append(contentsOf: MAGIC_FRAME)
+        let isKeyframe = false
+        header.append(isKeyframe ? FLAG_KEYFRAME : 0)
+        var len = UInt32(100).littleEndian
+        header.append(Data(bytes: &len, count: 4))
+
+        XCTAssertEqual(header[2], 0x00)
+    }
+
+    // MARK: - Command packet layout
+
+    func testCommandPacketIs4Bytes() {
+        // Build a command packet the same way TCPServer.sendCommand does:
+        // [magic:2][cmd:1][value:1]
+        var packet = Data(capacity: 4)
+        packet.append(contentsOf: MAGIC_CMD)
+        packet.append(CMD_BRIGHTNESS)
+        packet.append(128)
+
+        XCTAssertEqual(packet.count, 4)
+    }
+
+    func testCommandPacketMagicPrefix() {
+        var packet = Data()
+        packet.append(contentsOf: MAGIC_CMD)
+        packet.append(CMD_WARMTH)
+        packet.append(64)
+
+        XCTAssertEqual(packet[0], 0xDA)
+        XCTAssertEqual(packet[1], 0x7F)
+    }
+
+    func testCommandPacketCmdPosition() {
+        var packet = Data()
+        packet.append(contentsOf: MAGIC_CMD)
+        packet.append(CMD_BRIGHTNESS)
+        packet.append(200)
+
+        XCTAssertEqual(packet[2], CMD_BRIGHTNESS, "Command byte is at offset 2")
+    }
+
+    func testCommandPacketValuePosition() {
+        var packet = Data()
+        packet.append(contentsOf: MAGIC_CMD)
+        packet.append(CMD_WARMTH)
+        packet.append(42)
+
+        XCTAssertEqual(packet[3], 42, "Value byte is at offset 3")
+    }
+
+    // MARK: - Step constants
+
+    func testBrightnessStepIsPositive() {
+        XCTAssertGreaterThan(BRIGHTNESS_STEP, 0)
+    }
+
+    func testWarmthStepIsPositive() {
+        XCTAssertGreaterThan(WARMTH_STEP, 0)
+    }
+}

--- a/Tests/MirrorEngineTests/UpdateCheckerTests.swift
+++ b/Tests/MirrorEngineTests/UpdateCheckerTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import MirrorEngine
+
+final class UpdateCheckerTests: XCTestCase {
+
+    // MARK: - Same version
+
+    func testSameVersionIsNotNewer() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "1.0.0", local: "1.0.0"))
+    }
+
+    func testSameVersionTwoComponents() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "2.5", local: "2.5"))
+    }
+
+    func testSameVersionFourComponents() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "1.2.3.4", local: "1.2.3.4"))
+    }
+
+    // MARK: - Single component versions
+
+    func testSingleComponentNewer() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2", local: "1"))
+    }
+
+    func testSingleComponentOlder() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "1", local: "2"))
+    }
+
+    func testSingleComponentEqual() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "3", local: "3"))
+    }
+
+    // MARK: - Empty / malformed input
+
+    func testEmptyRemoteIsNotNewer() {
+        // Empty string → no numeric components → treated as 0.0.0
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "", local: "1.0.0"))
+    }
+
+    func testEmptyLocalMakesRemoteNewer() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "1.0.0", local: ""))
+    }
+
+    func testBothEmptyIsNotNewer() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "", local: ""))
+    }
+
+    // MARK: - Mismatched component counts
+
+    func testRemoteHasMoreComponents() {
+        // "1.0.0.1" vs "1.0.0" — remote has extra .1, treated as newer
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "1.0.0.1", local: "1.0.0"))
+    }
+
+    func testLocalHasMoreComponents() {
+        // "1.0.0" vs "1.0.0.1" — local has extra .1, remote is older
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "1.0.0", local: "1.0.0.1"))
+    }
+
+    func testTwoVsThreeComponents() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "1.1", local: "1.0"))
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "1.0", local: "1.1"))
+    }
+
+    // MARK: - Large version numbers
+
+    func testLargeVersionNumbers() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "100.200.300", local: "100.200.299"))
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "100.200.299", local: "100.200.300"))
+    }
+
+    // MARK: - Non-numeric components are dropped
+
+    func testNonNumericComponentsIgnored() {
+        // "v1.0.0" → split by "." → ["v1", "0", "0"] → compactMap Int → [0, 0]
+        // because "v1" is not a valid Int. This tests the raw isNewer behavior.
+        // The v-prefix stripping happens in check(), not isNewer().
+        // So "v1.0.0" effectively becomes [0, 0] (only "0" and "0" parse).
+        // vs "0.9.0" → [0, 9, 0]
+        // [0,0] vs [0,9,0] → 0==0, 0<9 → false
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "v1.0.0", local: "0.9.0"))
+    }
+
+    // MARK: - Boundary cases
+
+    func testZeroVersions() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "0.0.0", local: "0.0.0"))
+    }
+
+    func testZeroVsOne() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "0.0.1", local: "0.0.0"))
+    }
+
+    func testMajorBumpOverridesMinorAndPatch() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2.0.0", local: "1.99.99"))
+    }
+
+    func testMinorBumpOverridesPatch() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "1.2.0", local: "1.1.99"))
+    }
+}


### PR DESCRIPTION
## Summary

- **CI workflow**: Added `.github/workflows/ci.yml` — runs `swift build` + `swift test` on every PR and push to main. Catches build failures and test regressions early.
- **Test coverage 23 → 104**: Added 81 new unit tests across 4 new test files, covering wire protocol constants, MirrorStatus enum, DisplayController brightness/warmth/backlight logic, and UpdateChecker semver edge cases.
- **CONTRIBUTING.md**: Added contributor guide with prerequisites, build/test/run instructions, architecture overview, development workflow, and PR guidelines.

## New Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `ProtocolTests.swift` | 20 | Wire protocol magic bytes, frame header layout (7-byte LE), command packet layout, flag values, command ID uniqueness |
| `DisplayControllerTests.swift` | 25 | Initial state, brightness/warmth clamping (0-255), backlight toggle save/restore, callback firing |
| `MirrorStatusTests.swift` | 18 | Equality/inequality for all cases, error message matching, all 6 status cases constructable and distinct |
| `UpdateCheckerTests.swift` | 18 | Edge cases: empty strings, single-component versions, large numbers, non-numeric components, mismatched component counts |

## Testing

All 104 tests pass locally on macOS:

```
swift test
Executed 104 tests, with 0 failures (0 unexpected) in 0.010 seconds
```

No source files modified — tests only + CI + docs.