### PR TITLE
Fix dead-code warning in ProtocolTests

### DIFF
--- a/Tests/MirrorEngineTests/ProtocolTests.swift
+++ b/Tests/MirrorEngineTests/ProtocolTests.swift
@@ -100,8 +100,7 @@ final class ProtocolTests: XCTestCase {
     func testNonKeyframeHasFlagZero() {
         var header = Data()
         header.append(contentsOf: MAGIC_FRAME)
-        let isKeyframe = false
-        header.append(isKeyframe ? FLAG_KEYFRAME : 0)
+        header.append(0)
         var len = UInt32(100).littleEndian
         header.append(Data(bytes: &len, count: 4))
 


### PR DESCRIPTION
One-liner: the `isKeyframe` ternary used a `let false` constant, so the true branch was dead code and the compiler warned about it. Replaced with a direct `0` literal.

```diff
- let isKeyframe = false
- header.append(isKeyframe ? FLAG_KEYFRAME : 0)
+ header.append(0)
```