### PR TITLE
fix: extend mode: unmirror and reposition virtual display

### DIFF
--- a/Sources/MirrorEngine/DeviceSession.swift
+++ b/Sources/MirrorEngine/DeviceSession.swift
@@ -63,6 +63,11 @@ public class DeviceSession: Identifiable {
         if displayMode == .mirror {
             displayManager?.mirrorBuiltInDisplay()
         } else {
+            // macOS may auto-mirror the new virtual display with the built-in.
+            // Explicitly break any mirror relationship first, then position side-by-side.
+            displayManager?.unmirrorBuiltInDisplay()
+            try? await Task.sleep(for: .milliseconds(500))
+            displayManager?.positionNextToBuiltIn()
             NSLog("[Session:%@] Extended display mode — second screen", device.serial)
         }
         try? await Task.sleep(for: .seconds(1))

--- a/Sources/MirrorEngine/VirtualDisplayManager.swift
+++ b/Sources/MirrorEngine/VirtualDisplayManager.swift
@@ -60,6 +60,38 @@ class VirtualDisplayManager {
         print("Virtual display configured: \(width)x\(height) \(modeLabel) @ 60Hz")
     }
 
+    /// Position this virtual display to the right of the built-in display,
+    /// so they don't overlap. Used in extend mode.
+    func positionNextToBuiltIn() {
+        var displayIDs = [CGDirectDisplayID](repeating: 0, count: 32)
+        var displayCount: UInt32 = 0
+        CGGetOnlineDisplayList(32, &displayIDs, &displayCount)
+
+        var builtInID: CGDirectDisplayID?
+        for i in 0..<Int(displayCount) {
+            if CGDisplayIsBuiltin(displayIDs[i]) != 0 {
+                builtInID = displayIDs[i]
+                break
+            }
+        }
+
+        guard let masterID = builtInID else { return }
+
+        let builtInBounds = CGDisplayBounds(masterID)
+        let originX = Int32(builtInBounds.origin.x + builtInBounds.size.width)
+        let originY = Int32(builtInBounds.origin.y)
+
+        var configRef: CGDisplayConfigRef?
+        guard CGBeginDisplayConfiguration(&configRef) == .success, let config = configRef else { return }
+
+        // Ensure built-in stays at (0,0) — this keeps it as the primary/main display.
+        // macOS treats the display at origin (0,0) as the primary (menu bar + dock).
+        CGConfigureDisplayOrigin(config, masterID, 0, 0)
+        CGConfigureDisplayOrigin(config, displayID, originX, originY)
+
+        guard CGCompleteDisplayConfiguration(config, .forSession) == .success else { return }
+    }
+
     func mirrorBuiltInDisplay() {
         var displayIDs = [CGDirectDisplayID](repeating: 0, count: 32)
         var displayCount: UInt32 = 0


### PR DESCRIPTION
## Problem

When using **extend mode**, macOS automatically mirrors the newly created virtual display with the built-in display. This means extend mode ends up behaving identically to mirror mode — the user sees the same content on both screens instead of getting an independent second display.

## Solution

When the display mode is set to `.extend`, the fix:

1. **Breaks the auto-mirror relationship** by calling `unmirrorBuiltInDisplay()` (already exists in the codebase)
2. **Waits 500ms** for macOS to process the configuration change
3. **Repositions the virtual display** to the right of the built-in display using `CGConfigureDisplayOrigin`, so they sit side-by-side as expected

The new `positionNextToBuiltIn()` method on `VirtualDisplayManager`:
- Enumerates online displays to find the built-in one
- Places the virtual display immediately to the right of it
- Keeps the built-in at origin `(0,0)` so it remains the primary display (menu bar + dock)

## Test plan

- [ ] Launch with extend mode enabled
- [ ] Verify the virtual display appears as a separate, independent screen (not mirrored)
- [ ] Verify the built-in display retains the menu bar and dock
- [ ] Verify mirror mode still works as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)